### PR TITLE
feat: add JSON-LD structured data for events

### DIFF
--- a/app/(content)/page.tsx
+++ b/app/(content)/page.tsx
@@ -1,10 +1,19 @@
 import type { Metadata } from "next";
 import { About } from "@/components/sections/about";
+import { EventJsonLd } from "@/components/seo/event-json-ld";
+import { events } from "@/utils/data/events";
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || "https://dominikkoch.dev";
 
 export const metadata: Metadata = {
   description: "Software Engineer based in Germany. Open source enthusiast.",
 };
 
 export default async function Page() {
-  return <About />;
+  return (
+    <>
+      <EventJsonLd baseUrl={BASE_URL} events={events} />
+      <About />
+    </>
+  );
 }

--- a/components/seo/event-json-ld.tsx
+++ b/components/seo/event-json-ld.tsx
@@ -1,0 +1,54 @@
+import type { EventItem } from "@/utils/data/events";
+
+interface EventJsonLdProps {
+  events: EventItem[];
+  baseUrl: string;
+}
+
+export function EventJsonLd({ events, baseUrl }: EventJsonLdProps) {
+  const structuredData = events.map((event) => ({
+    "@context": "https://schema.org",
+    "@type": "Event",
+    name: event.name,
+    description: event.description,
+    startDate: event.startDate,
+    endDate: event.endDate,
+    eventStatus: "https://schema.org/EventScheduled",
+    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    location: event.eventLocation
+      ? {
+          "@type": "Place",
+          name: event.eventLocation.name,
+          address: {
+            "@type": "PostalAddress",
+            streetAddress: event.eventLocation.streetAddress,
+            addressLocality: event.eventLocation.addressLocality,
+            addressRegion: event.eventLocation.addressRegion,
+            postalCode: event.eventLocation.postalCode,
+            addressCountry: event.eventLocation.addressCountry,
+          },
+        }
+      : {
+          "@type": "Place",
+          name: event.location,
+        },
+    image: event.image ? `${baseUrl}${event.image}` : undefined,
+    url: `https://lu.ma/event/${event.lumaEventId}`,
+    organizer: {
+      "@type": "Person",
+      name: "Dominik Koch",
+      url: baseUrl,
+    },
+  }));
+
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(
+          structuredData.length === 1 ? structuredData[0] : structuredData
+        ),
+      }}
+      type="application/ld+json"
+    />
+  );
+}

--- a/components/seo/event-json-ld.tsx
+++ b/components/seo/event-json-ld.tsx
@@ -1,8 +1,22 @@
-import type { EventItem } from "@/utils/data/events";
+import type { EventItem, EventOrganizer } from "@/utils/data/events";
 
 interface EventJsonLdProps {
   events: EventItem[];
   baseUrl: string;
+}
+
+function formatOrganizers(organizers: EventOrganizer[] | undefined) {
+  if (!organizers || organizers.length === 0) {
+    return undefined;
+  }
+
+  const formatted = organizers.map((org) => ({
+    "@type": org.type,
+    name: org.name,
+    url: org.url,
+  }));
+
+  return formatted.length === 1 ? formatted[0] : formatted;
 }
 
 export function EventJsonLd({ events, baseUrl }: EventJsonLdProps) {
@@ -34,11 +48,7 @@ export function EventJsonLd({ events, baseUrl }: EventJsonLdProps) {
         },
     image: event.image ? `${baseUrl}${event.image}` : undefined,
     url: `https://lu.ma/event/${event.lumaEventId}`,
-    organizer: {
-      "@type": "Person",
-      name: "Dominik Koch",
-      url: baseUrl,
-    },
+    organizer: formatOrganizers(event.organizers),
   }));
 
   return (

--- a/utils/data/events.ts
+++ b/utils/data/events.ts
@@ -50,6 +50,16 @@ export const events: EventItem[] = [
         name: "Vercel",
         url: "https://vercel.com",
       },
+      {
+        type: "Person",
+        name: "Dominik Koch",
+        url: "https://dominikkoch.dev",
+      },
+      {
+        type: "Person",
+        name: "Gabby Shires",
+        url: "https://x.com/gabbyshires",
+      },
     ],
   },
 ];

--- a/utils/data/events.ts
+++ b/utils/data/events.ts
@@ -7,6 +7,12 @@ export interface EventLocation {
   addressCountry: string;
 }
 
+export interface EventOrganizer {
+  type: "Person" | "Organization";
+  name: string;
+  url?: string;
+}
+
 export interface EventItem {
   name: string;
   description: string;
@@ -18,6 +24,7 @@ export interface EventItem {
   startDate: string;
   endDate?: string;
   eventLocation?: EventLocation;
+  organizers?: EventOrganizer[];
 }
 
 export const events: EventItem[] = [
@@ -37,5 +44,12 @@ export const events: EventItem[] = [
       addressRegion: "Bavaria",
       addressCountry: "DE",
     },
+    organizers: [
+      {
+        type: "Organization",
+        name: "Vercel",
+        url: "https://vercel.com",
+      },
+    ],
   },
 ];

--- a/utils/data/events.ts
+++ b/utils/data/events.ts
@@ -1,3 +1,12 @@
+export interface EventLocation {
+  name?: string;
+  streetAddress?: string;
+  addressLocality: string;
+  addressRegion?: string;
+  postalCode?: string;
+  addressCountry: string;
+}
+
 export interface EventItem {
   name: string;
   description: string;
@@ -6,6 +15,9 @@ export interface EventItem {
   location: string;
   image?: string;
   lumaEventId: string;
+  startDate: string;
+  endDate?: string;
+  eventLocation?: EventLocation;
 }
 
 export const events: EventItem[] = [
@@ -18,5 +30,12 @@ export const events: EventItem[] = [
     location: "Munich, Germany",
     image: "/images/events/vercel-munich-2026.webp",
     lumaEventId: "evt-t82Utu2HPEFxUB3",
+    startDate: "2026-01-22T17:00:00+01:00",
+    endDate: "2026-01-22T20:00:00+01:00",
+    eventLocation: {
+      addressLocality: "Munich",
+      addressRegion: "Bavaria",
+      addressCountry: "DE",
+    },
   },
 ];


### PR DESCRIPTION
## Summary
- Adds JSON-LD structured data for events to improve SEO and enable rich results in Google Search
- Creates reusable `EventJsonLd` component that dynamically generates schema.org Event markup
- Extends `EventItem` interface with ISO 8601 dates and structured location data

## Changes
- **`components/seo/event-json-ld.tsx`**: New component that generates JSON-LD script tag from event data
- **`utils/data/events.ts`**: Added `startDate`, `endDate` (ISO 8601), and `eventLocation` fields to interface
- **`app/(content)/page.tsx`**: Integrated EventJsonLd component on home page

## Test plan
- [ ] Verify build passes (✓ already confirmed)
- [ ] Check page source for `<script type="application/ld+json">` tag
- [ ] Validate structured data with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Test with [Schema.org Validator](https://validator.schema.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)