### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single Next.js 16 (App Router) portfolio site. The package manager is **Bun** (see `bun.lock`); always use `bun`, not npm/pnpm.
+
+### Services
+- **Web app** (only service): Next.js dev server on `http://localhost:3000`.
+
+### Commands
+- Run dev: `bun run dev` (Turbopack). Standard scripts are in `package.json` (`dev`, `build`, `start`).
+- Lint/format: this project uses **Biome via Ultracite**, not ESLint. Use `bun x ultracite check` (lint) and `bun x ultracite fix` (autofix). The `lint` npm script (`eslint`) is vestigial — there is no ESLint config. Note: `bun x ultracite check` reports pre-existing diagnostics in the repo and still exits 0.
+- Build: `bun run build`.
+
+### Non-obvious caveats
+- External data sources (MarbleCMS via `MARBLE_API_KEY`, GitHub sponsors via `GITHUB_TOKEN`) are optional. Without keys, `lib/marble/*` and `lib/github/sponsors.ts` catch errors and return empty results, so dev/build still succeed. During `bun run build` you will see logged MarbleCMS fetch failures — these are expected without `MARBLE_API_KEY` and do not fail the build.
+- Copy `.env.example` to `.env` only if you need live blog/sponsor content; it is not required to run, build, or test the site.
+- `afterFileEdit` hook (`.cursor/hooks.json`) runs `bun x ultracite fix` automatically after edits.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Next.js 16 portfolio site and documents non-obvious caveats for future Cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the single web service, the Bun-based commands, the Biome/Ultracite (not ESLint) linter, and the fact that MarbleCMS/GitHub data sources degrade gracefully without API keys.
- Configures the update script as `bun install --frozen-lockfile`.

## Environment verification

| Service | Lint | Build | Run |
| --- | --- | --- | --- |
| Web app (Next.js) | `bun x ultracite check` | `bun run build` | `bun run dev` → http://localhost:3000 |

All routes return HTTP 200. End-to-end test confirmed homepage, Projects, and Tools pages render and the theme toggle works.

[portfolio_navigation_and_theme_demo.mp4](https://cursor.com/agents/bc-4d48622d-9210-4771-a6a3-c093e0c8d8bc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_navigation_and_theme_demo.mp4)

[Homepage light mode](https://cursor.com/agents/bc-4d48622d-9210-4771-a6a3-c093e0c8d8bc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_light.webp)
[Homepage dark mode](https://cursor.com/agents/bc-4d48622d-9210-4771-a6a3-c093e0c8d8bc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhome_dark.webp)

## Notes
- No application code was modified. Pre-existing Ultracite diagnostics and a MarbleCMS fetch warning during build (no API key) are expected and non-blocking.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d48622d-9210-4771-a6a3-c093e0c8d8bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d48622d-9210-4771-a6a3-c093e0c8d8bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

